### PR TITLE
Tomoscan+dm

### DIFF
--- a/src/tomo_2bm/configs/iconfig.yml
+++ b/src/tomo_2bm/configs/iconfig.yml
@@ -60,7 +60,7 @@ SPEC_DATA_FILES:
 
 ### APS Data Management
 ### Learn environment variables for Data Management from this file:
-DM_SETUP_FILE: "/home/dm/etc/dm.setup.sh"
+DM_SETUP_FILE: "/home/dm_bm/etc/dm.setup.sh"
 
 # ----------------------------------
 

--- a/src/tomo_2bm/plans/plans_with_dm.py
+++ b/src/tomo_2bm/plans/plans_with_dm.py
@@ -1,0 +1,54 @@
+"""
+Bluesky plans that execute APS Data Management workflows.
+
+Assumes ``apstools.utils.aps_data_management.dm_setup(bash_setup_file)``
+has been called before accessing any function from the ``aps-dm-api``
+package.  This is usually called in ``startup.py``.
+"""
+
+# FIXME: work-in-progress
+
+from typing import Any, Optional
+
+from apstools.devices.aps_data_management import DM_WorkflowConnector
+from bluesky.utils import plan as bluesky_plan
+
+_FOREVER = 999_999_999_999
+DM_WORKFLOW_REPORTING_TIMEOUT = _FOREVER
+
+
+@bluesky_plan
+def tomo_single_scan_dm(
+    *,  # kwargs-only (for queueserver use)
+    # TODO: experimentName: str = "",   # Name of APS DM experiment
+    workflow: str = "",  # Name of APS DM workflow
+    filePath: str = "",  # path to APS DM experiment files
+    dm_kwargs,: Optional[dict[atr, Any]] = {},  # _Any_ other kwargs for the DM workflow.
+    md: Optional[dict[atr, Any]] = {},
+):
+    """Run the tomo_single_scan() plan, then start a DM workflow."""
+    from tomo_2bm.plans.tomo_single import tomo_single_scan
+
+    # Add DM metadata to bluesky's metadata
+    _md = dict(
+        workflow=workflow,
+        filePath=filePath,
+    )
+    _md.update(dm_kwargs)
+    _md.update(md or {})
+
+    dm_workflow = DM_WorkflowConnector(name="dm_workflow", labels=["DM"])
+    dm.concise_reporting.put(True)  # brief DM workflow reports
+    dm.reporting_period.put(_FOREVER)  # (effectively) disable periodic DM workflow reporting
+
+    # Run tomoscan
+    yield from tomo_single_scan(md=_md)
+
+    # Start APS DM workflow, don't wait for it to finish.
+    yield from dm_workflow.run_as_plan(
+        workflow=workflow,
+        filePath=filePath,
+        wait=False,  # TODO: confirm: start the workflow, don't wait for it to finish
+        timeout=DM_WORKFLOW_REPORTING_TIMEOUT,
+        **dm_kwargs,
+    )

--- a/src/tomo_2bm/startup.py
+++ b/src/tomo_2bm/startup.py
@@ -48,7 +48,7 @@ instrument, oregistry = init_instrument("guarneri")
 oregistry.clear()
 
 # Setup APS Data Management
-# aps_dm_setup(iconfig.get("DM_SETUP_FILE"))
+aps_dm_setup(iconfig.get("DM_SETUP_FILE"))
 
 # Command-line tools, such as %wa, %ct, ...
 register_bluesky_magics()
@@ -90,8 +90,8 @@ make_devices(clear=False, file="devices.yml", device_manager=instrument)
 # Devices with the label 'baseline' will be added to the baseline stream.
 setup_baseline_stream(sd, oregistry, connect=False)
 
+from .plans.plans_with_dm import tomo_single_scan_dm  # noqa: E402, F401
 from .plans.sim_plans import sim_count_plan  # noqa: E402, F401
 from .plans.sim_plans import sim_print_plan  # noqa: E402, F401
 from .plans.sim_plans import sim_rel_scan_plan  # noqa: E402, F401
 from .plans.tomo_single import tomo_single_scan  # noqa: E402, F401
-# from .plans.plans_with_dm import tomo_single_scan_dm  # noqa: E402, F401

--- a/src/tomo_2bm/startup.py
+++ b/src/tomo_2bm/startup.py
@@ -29,6 +29,8 @@ from apsbits.utils.config_loaders import load_config
 from apsbits.utils.helper_functions import register_bluesky_magics
 from apsbits.utils.helper_functions import running_in_queueserver
 
+from apstools.utils.aps_data_management import dm_setup as aps_dm_setup
+
 # Configuration block
 # Get the path to the instrument package
 # Load configuration to be used by the instrument.
@@ -44,6 +46,9 @@ instrument, oregistry = init_instrument("guarneri")
 
 # Discard oregistry items loaded above.
 oregistry.clear()
+
+# Setup APS Data Management
+# aps_dm_setup(iconfig.get("DM_SETUP_FILE"))
 
 # Command-line tools, such as %wa, %ct, ...
 register_bluesky_magics()
@@ -89,3 +94,4 @@ from .plans.sim_plans import sim_count_plan  # noqa: E402, F401
 from .plans.sim_plans import sim_print_plan  # noqa: E402, F401
 from .plans.sim_plans import sim_rel_scan_plan  # noqa: E402, F401
 from .plans.tomo_single import tomo_single_scan  # noqa: E402, F401
+# from .plans.plans_with_dm import tomo_single_scan_dm  # noqa: E402, F401


### PR DESCRIPTION
Integrate new `tomo_single_scan()` with APS Data Management workflow.

Conda environment will need APS Data Management Python package:

```bash
conda install -n tomo-bits-decarlof aps-anl-tag::aps-dm-api
```